### PR TITLE
Fix typos, improve style consistency

### DIFF
--- a/src/11_final_code.md
+++ b/src/11_final_code.md
@@ -183,7 +183,7 @@ pub struct Runtime {
     epoll_registrator: minimio::Registrator,
     // The handle to our epoll thread
     epoll_thread: thread::JoinHandle<()>,
-    /// None = infinite, Some(n) = timeout in n ms, Some(0) = immidiate
+    /// None = infinite, Some(n) = timeout in n ms, Some(0) = immediate
     epoll_timeout: Arc<Mutex<Option<i32>>>,
     /// Channel used by both our threadpool and our epoll thread to send events
     /// to the main loop
@@ -379,7 +379,7 @@ impl Runtime {
             self.run_callbacks();
 
             // ===== 5. CHECK =====
-            // an set immidiate function could be added pretty easily but we
+            // an set immediate function could be added pretty easily but we
             // won't do that here
 
             // ===== 6. CLOSE CALLBACKS ======
@@ -387,7 +387,7 @@ impl Runtime {
             // where sockets etc are closed.
         }
 
-        // We clean up our resources, makes sure all destructors runs.
+        // We clean up our resources, makes sure all destructors run.
         for thread in self.thread_pool.into_iter() {
             thread.sender.send(Task::close()).expect("threadpool cleanup");
             thread.handle.join().unwrap();

--- a/src/1_concurrent_vs_parallel.md
+++ b/src/1_concurrent_vs_parallel.md
@@ -17,24 +17,27 @@ but not at the same time. Another is to progress tasks at the exact same time in
 ## Lets start off with some definitions
 
 ### Resource
+
 Something we need to be able to progress a task. Our resources are limited. This
 could be CPU time or memory.
 
 ### Task
+
 A set of operations that requires some kind of resource to progress. A task must
 consist of several sub-operations.
 
 ### Parallel
+
 Something happening independently at the **exact** same time.
 
 ### Concurrent
+
 Tasks that are **`in progress`** at the same time, but not *necessarily* progressing
 simultaneously.
 
 This is an important distinction. If two tasks are running concurrently,
 but are not running in parallel, they must be able to stop and resume their progress.
 We say that a task is `interruptable` if it allows for this kind of concurrency.
-
 
 ## The mental model I use.
 
@@ -48,7 +51,6 @@ The **why** has everything to do with resource utilization and [efficiency](http
 
 > Efficiency is the (often measurable) ability to avoid wasting materials, energy, efforts, money, and time in doing something or in producing a desired result.
 
-
 ### Parallelism
 
 Is increasing the resources we use to solve a task. It has nothing to do with _efficiency_.
@@ -58,7 +60,6 @@ Is increasing the resources we use to solve a task. It has nothing to do with _e
 Has everything to do with efficiency and resource utilization. Concurrency can never make _one single task go faster_.
 It can only help us utilize our resources better and thereby _finish a set of tasks faster_.
 
-
 ### Let's draw some parallels to process economics
 
 In businesses that manufacture goods, we often talk about LEAN processes. And this is pretty easy to compare with why programmers care so much about what we can achieve if we handle tasks concurrently.
@@ -67,7 +68,7 @@ I'll let let this 3 minute video explain it for me:
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Oz8BR5Lflzg" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-Ok, so it's not the newest video on the subject, but it explains a lot in 3 minutes. Most importantly the gains we try to achieve when applying LEAN techniques, and most importantly: **eliminate waiting and non-value-adding tasks.**
+OK, so it's not the newest video on the subject, but it explains a lot in 3 minutes. Most importantly the gains we try to achieve when applying LEAN techniques, and most importantly: **eliminate waiting and non-value-adding tasks.**
 
 > In programming we could say that we want to avoid `blocking` and `polling` (in a busy loop).
 
@@ -106,8 +107,7 @@ you can work on in parallel.
 **I can see two major use cases for concurrency:**
 
 1. When performing I/O and you need to wait for some external event to occur
-2. When you need to divide your attention and prevent one task from waiting too
-long
+2. When you need to divide your attention and prevent one task from waiting too long
 
 The first is the classic I/O example: you have to wait for a network
 call, a database query or something else to happen before you can progress a

--- a/src/2_async_history.md
+++ b/src/2_async_history.md
@@ -8,7 +8,7 @@ looked like a deck of these:
 ![Image](./images/punched_card_deck.jpg)
 
 There were operating systems being researched even very early and when personal computing
-started to grow in the '80s operating systems like DOS was the standard on most consumer
+started to grow in the 80s, operating systems like DOS were the standard on most consumer
 PCs.
 
 These operating systems usually yielded control of the entire CPU to the program currently executing and it was
@@ -29,10 +29,9 @@ Besides off-loading a huge responsibility to every programmer writing a program
 for your platform, this was naturally error-prone. A small mistake in a programs code
 could halt or crash the entire system.
 
->If you remember Windows 95, you also remember the times when a window hung and you could paint the entire screen with it (almost the same way as the end in Solitaire, the card game that came with Windows).
+> If you remember Windows 95, you also remember the times when a window hung and you could paint the entire screen with it (almost the same way as the end in Solitaire, the card game that came with Windows).
 >
-> This was reportedly a typical error in the code that was supposed to yield control
-to the operating system.
+> This was reportedly a typical error in the code that was supposed to yield control to the operating system.
 
 ## Preemptive multitasking
 
@@ -100,7 +99,7 @@ they will immediately stop and give control to an interrupt handler. This is how
 the CPU handles concurrency.
 
 
-> \* However, modern CPU can also do a lot of things in parallel. Most CPUs are
+> \* However, modern CPUs can also do a lot of things in parallel. Most CPUs are
 > pipelined, meaning that the next instruction is loaded while the current is
 > executing. It might have a branch predictor that tries to figure out what
 > instructions to load next.

--- a/src/3_0_the_operating_system.md
+++ b/src/3_0_the_operating_system.md
@@ -25,7 +25,6 @@ The operating system will make sure that all important processes get some time f
 > is that you can't know for sure and there is no guarantee that your code will be
 > left to run uninterrupted.
 
-
 ## Teaming up with the OS.
 
 When programming it's often easy to forget how many moving pieces that need to

--- a/src/3_2_cross_platform_abstractions.md
+++ b/src/3_2_cross_platform_abstractions.md
@@ -1,10 +1,10 @@
 # About writing cross-platform abstractions
 
-If you isolate the code needed only for Linux and MacOS, you'll see that it's not many lines of code to write. But once you want to make a cross-platform variant, the amount of code explodes.
+If you isolate the code needed only for Linux and macOS, you'll see that it's not many lines of code to write. But once you want to make a cross-platform variant, the amount of code explodes.
 
 This is a recurring problem when we're curious about how this works on three different platforms, but we need some basic understanding of how the different operating systems work under the covers.
 
-My experience, in general, is that Linux and MacOS have simpler API requiring fewer lines of code, and often (but not always) the exact same call works for both systems.
+My experience, in general, is that Linux and macOS have simpler API requiring fewer lines of code, and often (but not always) the exact same call works for both systems.
 
 Windows, on the other hand, is more complex, requires you to set up more structures to pass information (instead of using primitives), and often way more lines of code. What Windows does have is very good documentation so even though it's more work you'll also find the official documentation very helpful.
 

--- a/src/3_3_the_cpu_and_the_os.md
+++ b/src/3_3_the_cpu_and_the_os.md
@@ -46,6 +46,7 @@ fn main() {
 #     res
 # }
 ```
+
 Now we get a segmentation fault. Not surprising really, but how does the CPU
 know that we're not allowed to dereference this memory?
 
@@ -72,7 +73,6 @@ _We'll cover the first one here and the second in the next chapter._
 > If you want to know more about how this works in detail I will absolutely
 > recommend that you give [Philipp Oppermann's excellent series](https://os.phil-opp.com/)
 > a read. It's extremely well written and will answer all these questions and many more.
-
 
 ## How does the CPU prevent us from accessing memory we're not supposed to?
 

--- a/src/4_interrupts_firmware_io.md
+++ b/src/4_interrupts_firmware_io.md
@@ -27,7 +27,7 @@ network card:
 ## 1. Our code
 
 We register a socket. This happens by issuing a `syscall` to the OS. Depending
-on the OS we either get a  `file descriptor` (Macos/Linux) or a `socket` (Windows).
+on the OS we either get a  `file descriptor` (macOS/Linux) or a `socket` (Windows).
 
 The next step is that we register our interest in `read` events on that socket.
 
@@ -39,15 +39,15 @@ The next step is that we register our interest in `read` events on that socket.
 <li>
 We tell the operating system that we're interested in `Read` events but we want
 to wait for it to happen by `yielding` control over our thread to the OS. The OS
-then suspends our thread by storing the register state and switch to some other
-thread.
+then suspends our thread by storing the register state and switches to some
+other thread.
 
 **From our perspective this will be blocking our thread until we have data to read.**
 </li>
 <li>
 We tell the operating system that we're interested in `Read` events but we
-just want a handle to a the task which we can `poll` to check if the event is
-ready or not.
+just want a handle to a task which we can `poll` to check if the event is ready
+or not.
 
 **The OS will not suspend our thread, so this will not block our code**
 </li>
@@ -128,7 +128,6 @@ Depending on whether we chose alternative A, B or C the OS will:
 2. Return `Ready` on the next `poll`
 3. Wake the thread and return a `Read` event for the handler we registered.
 
-
 ## Interrupts
 
 As I hinted at above, there are two kinds of interrupts:
@@ -145,7 +144,6 @@ Hardware interrupts are created by sending an electrical signal through an [Inte
 ### Software Interrupts
 
 These are interrupts issued from software instead of hardware. As in the case of a hardware interrupt, the CPU jumps to the Interrupt Descriptor Table and runs the handler for the specified interrupt.
-
 
 ### Firmware
 

--- a/src/5_strategies_for_handling_io.md
+++ b/src/5_strategies_for_handling_io.md
@@ -20,7 +20,6 @@ Now one way of accomplishing this is letting the OS take care of everything for 
 - The OS has many things it needs to handle. It might not switch back to your thread as fast as you'd wish
 - The OS doesn't know which tasks to prioritize, and you might want to give some tasks a higher priority than others.
 
-
 ## 2. Green threads
 
 Another common way of handling this is green threads. Languages like Go uses this to great success. In many ways this is similar to what the OS does but the runtime can be better adjusted and suited to your specific needs.
@@ -36,7 +35,6 @@ Another common way of handling this is green threads. Languages like Go uses thi
 
 - You need a runtime, and by having that you are duplicating part of the work the OS already does. The runtime will have a cost which in some cases can be substantial.
 - Can be difficult to implement in a flexible way to handle a wide variety of tasks
-
 
 ## 3. Poll based event loops supported by the OS
 
@@ -58,7 +56,6 @@ Now, we still need a way to "suspend" many tasks while waiting, and this is wher
 - Great flexibility comes with a good deal of complexity
 - Difficult to write an ergonomic API with an abstraction layer that accounts for the differences between the operating systems without introducing unwanted costs.
 - Only solves part of the problem—the programmer still needs a strategy for suspending tasks that are waiting.
-
 
 ## Final note
 

--- a/src/6_epoll_kqueue_iocp.md
+++ b/src/6_epoll_kqueue_iocp.md
@@ -15,8 +15,8 @@ Since we want
 to understand how everything works, I decided to create an extremely
 simplified version of an event queue. I called it `minimio` since it's greatly inspired by `mio`.
 
-> I have written about how this works in detail in [Epoll, Kqueue and IOCP explained](https://cfsamsonbooks.gitbook.io/epoll-kqueue-iocp-explained/). 
-> In that book we also create the event loop which we will use as the cross platform eventloop in this book. You can visit the code at its [Github repository if you're
+> I have written about how this works in detail in [Epoll, Kqueue and IOCP explained](https://cfsamsonbooks.gitbook.io/epoll-kqueue-iocp-explained/).
+> In that book we also create the event loop which we will use as the cross platform event loop in this book. You can visit the code at its [Github repository if you're
 > curious](https://github.com/cfsamson/examples-minimio).
 
 Nevertheless, we'll give each of them a brief introduction here so you know the basics.
@@ -25,7 +25,7 @@ Nevertheless, we'll give each of them a brief introduction here so you know the 
 
 If you remember my previous chapters, you know that we need to cooperate closely
 with the OS to make I/O operations as efficient as possible. Operating systems like
-Linux, MacOS and Windows provide several ways of performing I/O, both blocking and
+Linux, macOS and Windows provide several ways of performing I/O, both blocking and
 non-blocking.
 
 So blocking operations are the least flexible to use for us as programmers since we yield control to the OS, which suspends our thread. The big advantage is that our thread gets woken up once the event we're waiting for is ready.
@@ -66,14 +66,13 @@ Below is a basic breakdown of what happens in this type of event queue:
    completed.
 5. Our thread is unblocked, and our buffer is now filled with the data we're interested in.
 
-
 ## Epoll
 
 `Epoll` is the Linux way of implementing an event queue. In terms of functionality, it has a lot in common with `Kqueue`. The advantage of using `epoll` over other similar methods on Linux like `select` or `poll` is that `epoll` was designed to work very efficiently with a large number of events.
 
 ### Kqueue
 
-`Kqueue` is the MacOS way of implementing an event queue, which originated from BSD, in operating systems such as FreeBSD, OpenBSD, etc. In terms of high level functionality,
+`Kqueue` is the macOS way of implementing an event queue, which originated from BSD, in operating systems such as FreeBSD, OpenBSD, etc. In terms of high level functionality,
 it's similar to `Epoll` in concept but different in actual use.
 
 Some argue it's a bit more complex to use and a bit more abstract and "general".

--- a/src/7_0_introducing_our_main_example.md
+++ b/src/7_0_introducing_our_main_example.md
@@ -94,13 +94,14 @@ Our code here is mostly calling functions that register an event and stores a
 callback to be run when the event is ready.
 
 **An example of this is the `set_timeout` function:**
+
 ```rust, no_run
 set_timeout(0, |_res| {
     print("Immediate1 timed out");
 });
 ```
 
-What we really do here is register interest in a `timeout` event, and when that event occurs we want to run the
+What we really do here is register interest in a `timeout` event, and when that event occurs we want to run
 the callback `|_res| { print("Immediate1 timed out"); }`.
 
 Now the parameter `_res` is
@@ -116,6 +117,7 @@ Can't display video.
 </video>
 
 And here is what our output will look like:
+
 ```
 Thread: main     First call to read test.txt
 Thread: main     Registering immediate timeout 1
@@ -183,5 +185,3 @@ Thread: main     FINISHED
 
 Don't worry, we'll explain everything, but I just wanted to start off by
 explaining where we want to end up.
-
-

--- a/src/7_1_what_is_node.md
+++ b/src/7_1_what_is_node.md
@@ -55,7 +55,7 @@ Tasks that are predominately CPU intensive are handled by a thread pool. The def
 
 I/O tasks which can't be handled by the cross platform event queue are also handled here, which is the case with file reads that we use in our example.
 
-Most C++ extensions for Node uses this thread pool to perform their work, and that is one of many reasons they are used for calculation-intensive tasks.
+Most C++ extensions for Node use this thread pool to perform their work, and that is one of many reasons they are used for calculation-intensive tasks.
 
 ## Further Information
 
@@ -71,6 +71,4 @@ This first talk one is held by [@piscisaureus](https://github.com/piscisaureus) 
 The second one is slightly longer but is also an excellent talk held by [Bryan Hughes](https://github.com/nebrius)
 <iframe width="560" height="315" src="https://www.youtube.com/embed/zphcsoSJMvM" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-
 Now, relax, get a cup of tea and sit back while we go through everything together.
-

--- a/src/7_2_whats_our_plan.md
+++ b/src/7_2_whats_our_plan.md
@@ -43,7 +43,6 @@ and when. To help with that we define three extra methods:
 
 `current` is just a shortcut for us to get the name of the current thread. Since we want to track what's happening, we're going to need to print out which thread is issuing what output, so this will avoid cluttering up our code too much along the way.
 
-
 ## Minimio
 
 Minimio is a cross platform epoll/kqueue/IOCP based event loop that we will cover in the next book. I originally included it here, but implementing that for three architectures turned out to be a bit more involved than I first thought and needed more space than would fit in this book.

--- a/src/8_0_implementing_our_own_runtime.md
+++ b/src/8_0_implementing_our_own_runtime.md
@@ -95,6 +95,7 @@ impl Task {
     }
 }
 ```
+
 We need a task object, which represents a task we want to finish in our thread
 pool. I'll go through the types in this object in a later [chapter](./8_9_infrastructure.md) so don't worry too much about them now if you find them
 hard to grasp. Everything will be explained.
@@ -177,8 +178,8 @@ impl Js {
 
 ## PollEvent
 
-Next we have a the `PollEvent`. While we defined an `enum` to represent what
-kind of events we could send **to** the `eventpool` we define some events
+Next we have the `PollEvent`. While we defined an `enum` to represent what
+kind of events we could send **to** the `eventpool`, we define some events
 that we can accept back from both our `epoll based` event queue and our `threadpool`.
 
 ```rust,no_run

--- a/src/8_1_the_main_loop.md
+++ b/src/8_1_the_main_loop.md
@@ -17,7 +17,6 @@ impl Runtime {
 
 ## Initialization
 
-
 ```rust, no_run
 let rt_ptr: *mut Runtime = &mut self;
 unsafe { RUNTIME = rt_ptr };
@@ -34,7 +33,7 @@ variable `RUNTIME`.
 We could instead pass our `runtime` around but that wouldn't
 be very ergonomic. Another option would be to use `lazy_static` crate to initialize this field in a slightly safer way, but we'd have to explain what `lazy_static` do to keep our promise of minimal "magic".
 
-To be honest, we only set this once, and it's set at the start of of our eventloop and we only access this from the same thread we created it. It might not be pretty but it's safe.
+To be honest, we only set this once, and it's set at the start of of our event loop and we only access this from the same thread we created it. It might not be pretty but it's safe.
 
 `ticks` is only a counter for us to keep track of how many times we've looped which for display.
 
@@ -48,7 +47,7 @@ while self.pending_events > 0 {
     ticks += 1;
 ```
 
-`self.pending_events` keeps track of how many pending events we have, so that when no events are left we exit the loop since our eventloop is finished.
+`self.pending_events` keeps track of how many pending events we have, so that when no events are left we exit the loop since our event loop is finished.
 
 So where does these events come from? In our `javascript` function `f` which we introduced in the chapter [Introducing our main example](./7_0_introducing_our_main_example.md) you probably noticed that we called functions like
 `set_timeout` and `Fs::read`. These functions are defined in the Node runtime
@@ -140,9 +139,8 @@ We'll explain these methods in the following chapters.
 // an set immediate function could be added pretty easily but we won't that here
 ```
 
-Node implements a check "hook" to the eventloop next. Calls to `setImmidiate`
-execute here. I just include it for for completeness but we won't do anything in this phase.
-
+Node implements a check "hook" to the event loop next. Calls to `setImmediate`
+execute here. I just include it for completeness but we won't do anything in this phase.
 
 ## 6. Close Callbacks
 
@@ -160,7 +158,7 @@ like closing sockets, is done here.
 Since our `run` function basically will be the start and end of our `Runtime` we also need to clean up after ourselves. The following code makes sure all threads finish, release their resources and run all destructors:
 
 ```rust
-// We clean up our resources, makes sure all destructors runs.
+// We clean up our resources, makes sure all destructors run.
 for thread in self.thread_pool.into_iter() {
     thread.sender.send(Task::close()).expect("threadpool cleanup");
     thread.handle.join().unwrap();
@@ -184,7 +182,7 @@ pub fn run(mut self, f: impl Fn()) {
     let rt_ptr: *mut Runtime = &mut self;
     unsafe { RUNTIME = rt_ptr };
 
-    // just for us priting out during execution
+    // just for us printing out during execution
     let mut ticks = 0;
 
     // First we run our "main" function
@@ -193,7 +191,7 @@ pub fn run(mut self, f: impl Fn()) {
     // ===== EVENT LOOP =====
     while self.pending_events > 0 {
         ticks += 1;
-        // NOT PART OF LOOP, JUST FOR US TO SEE WHAT TICK IS EXCECUTING
+        // NOT PART OF LOOP, JUST FOR US TO SEE WHAT TICK IS EXECUTING
         print(format!("===== TICK {} =====", ticks));
 
         // ===== 2. TIMERS =====
@@ -241,7 +239,7 @@ pub fn run(mut self, f: impl Fn()) {
         self.run_callbacks();
 
         // ===== 5. CHECK =====
-        // an set immidiate function could be added pretty easily but we
+        // an set immediate function could be added pretty easily but we
         // won't do that here
 
         // ===== 6. CLOSE CALLBACKS ======
@@ -249,7 +247,7 @@ pub fn run(mut self, f: impl Fn()) {
         // where sockets etc are closed.
     }
 
-    // We clean up our resources, makes sure all destructors runs.
+    // We clean up our resources, makes sure all destructors run.
     for thread in self.thread_pool.into_iter() {
         thread.sender.send(Task::close()).expect("threadpool cleanup");
         thread.handle.join().unwrap();
@@ -261,7 +259,6 @@ pub fn run(mut self, f: impl Fn()) {
     print("FINISHED");
 }
 ```
-
 
 ## Shortcuts
 

--- a/src/8_2_setting_up_runtime.md
+++ b/src/8_2_setting_up_runtime.md
@@ -2,7 +2,7 @@
 
 ## The Threadpool
 
-We still don't have a threadpool or a I/O eventloop running
+We still don't have a threadpool or a I/O event loop running
 so the next step is to set this up.
 
 ### Let's take this step by step
@@ -242,6 +242,7 @@ we can send this to our `epoll` thread.
 
 Next up is spawning our thread. We do this the exact same way as for the thread
 pool, but we name the thread `epoll`.
+
 ```rust, no_run
 let epoll_thread = thread::Builder::new()
     .name("epoll".to_string())
@@ -376,6 +377,7 @@ Worth noting is that we know all threads are available here so `(0..4).collect()
 will just create a `Vec<usize>` with the values `[0, 1, 2, 3]`.
 
 In Rust, when we write...
+
 ```rust
 ...
 epoll_registrator: registrator,

--- a/src/8_3_timers.md
+++ b/src/8_3_timers.md
@@ -35,7 +35,7 @@ The first thing to note here is that we check `self.timers` and to understand th
 rest of the syntax we'll have to look what kind of collection this is.
 
 Now I chose a `BTreeMap<Instant, usize>` for this collection. The reason is that
-i want to have many `Instant`'s chronologically. When I add a timer, I calculate
+I want to have many `Instant`'s chronologically. When I add a timer, I calculate
 at what instance it's supposed to be run and I add that to this collection.
 
 > BTrees are a very good data structure when you know that your keys will be ordered.
@@ -49,7 +49,7 @@ operation without allocating a small buffer every time. You can iterate over the
 but due to the ownership rules you can't remove them at the same time, and we want to
 remove the timers, that we're done with.
 
-The eventloop will run repeatedly so avoiding any allocations inside the loop is smart. There is no need to have this overhead.
+The event loop will run repeatedly, so avoiding any allocations inside the loop is smart. There is no need to have this overhead.
 
 ```rust
 while let Some(key) = timers_to_remove.pop() {

--- a/src/8_4_callbacks.md
+++ b/src/8_4_callbacks.md
@@ -26,9 +26,7 @@ So when we've got a `callback_id` we find the corresponding callback we have sto
 
 `cb(data)` runs the code in this closure. After it's done it's time to decrease our counter of pending events: `self.pending_events -= 1;`.
 
-> Now, this step is important. As you might understand, any long running code in this callback is going to block our `eventloop`, preventing it from progressing. So no new callbacks are handled and no new events are registered. This is why it's bad to write code that blocks the eventloop.
-
-
+> Now, this step is important. As you might understand, any long running code in this callback is going to block our `event loop`, preventing it from progressing. So no new callbacks are handled and no new events are registered. This is why it's bad to write code that blocks the event loop.
 
 Let's recap by looking at what members of the `Runtime` struct we used here:
 

--- a/src/8_5_threadpool.md
+++ b/src/8_5_threadpool.md
@@ -10,7 +10,7 @@ file I/O will be `Ready` almost immediately, so waiting for that in a event queu
 has very little effect in practice.
 
 The second reason is that while Windows do have a completion based model, Linux
-and Macos doesn't. Reading a file into a buffer which your process controls can take some
+and macOS doesn't. Reading a file into a buffer which your process controls can take some
 time, and if we do that in our main loop it will block a little bit which we really try
 to avoid.
 

--- a/src/8_8_cleaning_up.md
+++ b/src/8_8_cleaning_up.md
@@ -4,7 +4,7 @@ Lastly we clean up after ourselves by joining all our threads so we know that
 all destructors have ran without errors after we're finished.
 
 ```rust, no_run
-// We clean up our resources, makes sure all destructors runs.
+// We clean up our resources, make sure all destructors run.
 for thread in self.thread_pool.into_iter() {
     thread.sender.send(Event::close()).expect("threadpool cleanup");
     thread.handle.join().unwrap();

--- a/src/9_1_file_module.md
+++ b/src/9_1_file_module.md
@@ -79,10 +79,10 @@ well implemented. The only system that does this pretty good is Windows since it
 uses a `completion` based model (which means it can let you know when the data is
 read into your buffer).
 
-> With the introduction of [io_uring](https://kernel.dk/io_uring.pdf) linux has arguably made
+> With the introduction of [io_uring](https://kernel.dk/io_uring.pdf) Linux has arguably made
 significant improvements in this regard, and now supports a _completion_ based model as well. At the
 time of writing this book it's still early but the reports so far has been very promising. We
-might expect to see changes in the way we handle cross platform eventloops in the future due to the
+might expect to see changes in the way we handle cross platform event loops in the future due to the
 fact that there is now two major systems supporting high performance completion based models.
 
 It makes sense for a completion based model to try to do this asynchronously, but
@@ -90,7 +90,7 @@ since the real effect are so small and the code complexity is high (especially w
 writing a server that is cross platform) most implementations find that using a thread pool
 gives good enough performance.
 
-To sum i all up:
+To sum it all up:
 
 **Threadpool:**
 
@@ -102,7 +102,7 @@ To sum i all up:
 **Async file I/O:**
 
 - Increased code complexity
-- Poor and limited APIs (Linux and Macos has different limitations)
+- Poor and limited APIs (Linux and macOS has different limitations)
 - Weak platform support (does not work very well with a readiness based model)
 - Little to no real gain for most use cases
 

--- a/src/9_2_crypto_module.md
+++ b/src/9_2_crypto_module.md
@@ -27,6 +27,7 @@ impl Crypto {
     }
 }
 ```
+
 Well, um, this is disappointing if you're into crypto. I'm sorry. The logic here is not very interesting, we take a number `n` as argument and calculate
 the n'th fibonacchi number recursively. A famous and inefficient way of putting your
 CPU to work.

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -50,7 +50,7 @@ understanding of how async code works in general, and the different strategies t
 
 - Think using our research to write a **toy** node.js runtime is pretty cool.
 
-- Want to know more about what the Node eventloop really is, and why most diagrams of it on the web are pretty misleading.
+- Want to know more about what the Node event loop really is, and why most diagrams of it on the web are pretty misleading.
 
 - Already know some Rust but want to learn more.
 
@@ -86,15 +86,15 @@ will not repeat everything here. However, it's definitely not a must.
 
 ## Disclaimer
 
-1. We'll implement a **toy** version of the Node.js eventloop (a bad, but working and conceptually similar eventloop)
+1. We'll implement a **toy** version of the Node.js event loop (a bad, but working and conceptually similar event loop)
 
 2. We'll **not** primarily focus on code quality and safety, though this is important,
-I will focus on understanding the concepts and ideas behind the code. We will have to make
-many shortcuts to keep this concise and short.
+   I will focus on understanding the concepts and ideas behind the code. We will have to make
+   many shortcuts to keep this concise and short.
 
 3. I will however do my best to point out hazards and the shortcuts we make.
-I will try to point out obvious places we could do a better job or take big
-shortcuts.
+   I will try to point out obvious places we could do a better job or take big
+   shortcuts.
 
 > Even though we
 > cover some complex topics we'll have to simplify them significantly to be able


### PR DESCRIPTION
I've done some cleanup. I'm not sure why the book's Markdown uses a mix of short (clipped to a certain character limit) and long (without line breaks) lines . Multiple authors maybe? I've left those untouched, as I'm not sure what's preferred here.